### PR TITLE
Ensure source repo update for fresh cocoapods installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ install_dependencies:
 	overcommit --install
 	overcommit --sign
 	overcommit --sign pre-commit
-	pod install
+	pod install --repo-update
 


### PR DESCRIPTION
In case of no previous cocoapods installation and usage, `pod install` will fail with following error:

```
[!] CocoaPods could not find compatible versions for pod "Bond":
  In snapshot (Podfile.lock):
    Bond (= 7.5.0)

  In Podfile:
    Bond

None of your spec sources contain a spec satisfying the dependencies: `Bond, Bond (= 7.5.0)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```

If `make install_dependencies` is used to set up environment in this case, it will fail.