### PR TITLE
Fixing memory leaks

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
-  - Alamofire (4.7.3)
-  - AlamofireObjectMapper (5.1.0):
-    - Alamofire (~> 4.1)
-    - ObjectMapper (~> 3.3)
-  - AppCenter (1.9.0):
-    - AppCenter/Analytics (= 1.9.0)
-    - AppCenter/Crashes (= 1.9.0)
-  - AppCenter/Analytics (1.9.0):
+  - Alamofire (4.8.2)
+  - AlamofireObjectMapper (5.2.0):
+    - Alamofire (~> 4.7)
+    - ObjectMapper (~> 3.4)
+  - AppCenter (2.2.0):
+    - AppCenter/Analytics (= 2.2.0)
+    - AppCenter/Crashes (= 2.2.0)
+  - AppCenter/Analytics (2.2.0):
     - AppCenter/Core
-  - AppCenter/Core (1.9.0)
-  - AppCenter/Crashes (1.9.0):
+  - AppCenter/Core (2.2.0)
+  - AppCenter/Crashes (2.2.0):
     - AppCenter/Core
-  - Bond (7.5.0):
+  - Bond (7.6.0):
     - Differ (~> 1.3)
     - ReactiveKit (~> 3.10)
   - Differ (1.4.3)
-  - ObjectMapper (3.3.0)
-  - ReactiveKit (3.12.2)
-  - Realm (3.11.0):
-    - Realm/Headers (= 3.11.0)
-  - Realm/Headers (3.11.0)
-  - RealmSwift (3.11.0):
-    - Realm (= 3.11.0)
-  - SwiftLint (0.27.0)
+  - ObjectMapper (3.5.1)
+  - ReactiveKit (3.13.0)
+  - Realm (3.17.3):
+    - Realm/Headers (= 3.17.3)
+  - Realm/Headers (3.17.3)
+  - RealmSwift (3.17.3):
+    - Realm (= 3.17.3)
+  - SwiftLint (0.34.0)
 
 DEPENDENCIES:
   - Alamofire
@@ -47,17 +47,17 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  AlamofireObjectMapper: 3395e698901d8b0e6f48b7d0c43bd47875325102
-  AppCenter: 3cf7b9387549e9703dab068793e404013e8c0cc1
-  Bond: 6abbc33a4cf88e65a0f8b1ba8276ac34584ad897
+  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
+  AlamofireObjectMapper: 92b6ce2423a9d159e686f6a1d514a009bf903ddc
+  AppCenter: c809e69d93218b9861b4f8e54ded8dcf4d2131e7
+  Bond: 5d626bfbbfc60b213ec35badb8f4fd81beff6a5f
   Differ: 6c7477d6187e8c36d02ec342a3c321061b85a0ea
-  ObjectMapper: b612bf8c8e99c4dc0bb6013a51f7c27966ed5da9
-  ReactiveKit: 33adc5550145e8200daa3eb210841f2a0be642c6
-  Realm: 92f09a102692b96a9a10e9617f214f15c5ab85fc
-  RealmSwift: 5f0481cd658bb751c509314b964a35eaa264d2cf
-  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
+  ObjectMapper: 70187b8941977c62ccfb423caf6b50be405cabf0
+  ReactiveKit: 4a938b0671b0b068232926a443da19d535a03023
+  Realm: 5a1d9d47bfc101dd597668b1a8af4288a2557f6d
+  RealmSwift: b7fdc2d18616621c31df5c7a398a45a2163f8eb0
+  SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: e7a3d22f6eccc75fc0b53985af9cdb9ff7d52b3a
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.5

--- a/Readme.md
+++ b/Readme.md
@@ -68,4 +68,4 @@ AppCentar
 
 ## Maintainers
 
-- [Haris Dizdarevic](https://github.com/haris-dizdarevic), [Zaharije Pasalic](https://github.com/zpasal)
+- [Haris Dizdarevic](https://github.com/haris-dizdarevic), [Zaharije Pasalic](https://github.com/zpasal) and [Adin Ćebić](https://github.com/adincebic)

--- a/SwiftTemplate/Scenes/Base/AppNavigator.swift
+++ b/SwiftTemplate/Scenes/Base/AppNavigator.swift
@@ -7,9 +7,10 @@ protocol AppNavigatorProtocol {
 }
 
 class AppNavigator: AppNavigatorProtocol {
-    let navigationController: UINavigationController
 
-    init(navigationController: UINavigationController) {
+    weak var navigationController: UINavigationController?
+
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
 
@@ -18,8 +19,8 @@ class AppNavigator: AppNavigatorProtocol {
                                                                                        .welcome)
         let welcomeNavigator = WelcomeNavigator(navigationController: navigationController)
         welcomeViewController.viewModel = WelcomeViewModel(welcomeNavigator: welcomeNavigator)
-        navigationController.setNavigationBarHidden(true, animated: false)
-        navigationController.pushViewController(welcomeViewController, animated: true)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.pushViewController(welcomeViewController, animated: true)
     }
 
     func goToHome() {
@@ -35,15 +36,15 @@ class AppNavigator: AppNavigatorProtocol {
         userViewController.tabBarItem = UITabBarItem(tabBarSystemItem: .contacts, tag: 2)
         tabBarController.viewControllers = [countriesViewController, userViewController]
         // Until we implement logout and sidemenu
-        navigationController.pushViewController(tabBarController, animated: true)
+        navigationController?.pushViewController(tabBarController, animated: true)
     }
 
     func goToLogin() {
         let loginViewController = LoginViewController.instantiateFromAppStoryboard(appStoryboard: .login)
         let loginNavigator = LoginNavigator(navigationController: navigationController)
         loginViewController.viewModel = LoginViewModelFactory.create(with: loginNavigator)
-        navigationController.setNavigationBarHidden(false, animated: false)
-        navigationController.pushViewController(loginViewController, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.pushViewController(loginViewController, animated: true)
     }
 
 }

--- a/SwiftTemplate/Scenes/Base/AppViewController.swift
+++ b/SwiftTemplate/Scenes/Base/AppViewController.swift
@@ -17,8 +17,8 @@ class AppViewController<TViewModel: AppViewModel>: UIViewController {
     }
 
     func bindViewModel() {
-        _ = viewModel.error.observeNext { (error) in
-            self.showError(error: error)
+        _ = viewModel.error.observeNext { [weak self] (error) in
+            self?.showError(error: error)
         }
     }
 

--- a/SwiftTemplate/Scenes/Base/AppViewModel.swift
+++ b/SwiftTemplate/Scenes/Base/AppViewModel.swift
@@ -11,6 +11,7 @@ import Bond
 import ReactiveKit
 
 class AppViewModel {
+
     var error = Property<AppError?>(nil)
 
     init() {}

--- a/SwiftTemplate/Scenes/Login/LoginViewModel.swift
+++ b/SwiftTemplate/Scenes/Login/LoginViewModel.swift
@@ -11,6 +11,7 @@ import ReactiveKit
 import Bond
 
 class LoginViewModel: AppViewModel {
+
     let loginRepository: LoginRepository!
     let loginNavigator: AppNavigatorProtocol
     // Input
@@ -23,7 +24,9 @@ class LoginViewModel: AppViewModel {
         self.loginRepository = loginRepository
         self.loginNavigator = loginNavigator
         super.init()
-        self.loginRepository.loginCompletionHandler = onLoginCompletedHandler
+        self.loginRepository.loginCompletionHandler = { [weak self] (error) in
+            self?.onLoginCompletedHandler(error)
+        }
     }
 
     func doLogin() {

--- a/SwiftTemplate/Scenes/Login/RegistrationViewController.swift
+++ b/SwiftTemplate/Scenes/Login/RegistrationViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class RegistrationViewController: AppViewController<RegistrationViewModel> {
+
     @IBOutlet weak var usernameTextField: UITextField!
     @IBOutlet weak var passwordTextField: UITextField!
 

--- a/SwiftTemplate/Scenes/Login/RegistrationViewModel.swift
+++ b/SwiftTemplate/Scenes/Login/RegistrationViewModel.swift
@@ -22,7 +22,9 @@ class RegistrationViewModel: AppViewModel {
         self.userRepository = userRepository
         self.registrationNavigator = registrationNavigator
         super.init()
-        self.userRepository.userActionCompletionHandler = onUserActionCompletedHandler
+        self.userRepository.userActionCompletionHandler = { [weak self] (error) in
+            self?.onUserActionCompletedHandler(error)
+        }
     }
 
     func doRegistration() {

--- a/SwiftTemplate/Scenes/Welcome/WelcomeNavigator.swift
+++ b/SwiftTemplate/Scenes/Welcome/WelcomeNavigator.swift
@@ -19,7 +19,7 @@ class WelcomeNavigator: AppNavigator, WelcomeNavigatorProtocol {
         let registrationNavigator = RegistrationNavigator(navigationController: navigationController)
         registrationViewController.viewModel = RegistrationViewModelFactory
             .create(with: registrationNavigator)
-        navigationController.setNavigationBarHidden(false, animated: false)
-        navigationController.pushViewController(registrationViewController, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.pushViewController(registrationViewController, animated: true)
     }
 }


### PR DESCRIPTION
I have gone through the Klika Swift template and fixed a number of memory leaks.

* Changed base AppNavigator to hold a weak reference to UINavigationController. Since the application's UIWindow is holding the reference to the UINavigationController, navigator classes should not increase the reference count of UINavigationController.
* Fixed the strong reference cycle in base AppViewController which caused each viewController to be strongly tied to it's viewmodel. Now, ViewController and viewModel do not hold a strong reference between each other and are being deallocated from memory.
* Fixed strong references between viewModels and repositories caused by strongly capturing self when passing closures between them.

I have profiled the application using instruments and allocations template and successfuly verified that above mentioned memory leaks are no longer present.