### PR TITLE
Convert completion handler calls to callback based calls

### DIFF
--- a/SwiftTemplate/Repositories/LoginRepository.swift
+++ b/SwiftTemplate/Repositories/LoginRepository.swift
@@ -8,23 +8,25 @@
 
 import Foundation
 
-typealias LoginServiceLoginCompletion = (_ error: ApiError?) -> Void
+typealias LoginCallback = (_ error: ApiError?) -> Void
 
 protocol LoginRepositoryProtocol {
-     func signIn(username: String, password: String)
+     func signIn(username: String, password: String, callback: @escaping LoginCallback)
 }
 
 class LoginRepository: LoginRepositoryProtocol {
-    var loginCompletionHandler: LoginServiceLoginCompletion?
+    private let apiClient: UserApiClient
 
-    func signIn(username: String, password: String) {
-        UserApiClient().signIn(username: username, password: password, callback: onSignInCompleted)
+    init(apiClient: UserApiClient = UserApiClient()) {
+        self.apiClient = apiClient
     }
 
-    private func onSignInCompleted(_ accessToken: AccessToken?, _ error: ApiError?) {
-        if let accessToken = accessToken {
-            SessionStore.currentSession.save(accessToken: accessToken)
+    func signIn(username: String, password: String, callback: @escaping LoginCallback) {
+        apiClient.signIn(username: username, password: password) { token, error in
+            if let accessToken = token {
+                SessionStore.currentSession.save(accessToken: accessToken)
+            }
+            callback(error)
         }
-        loginCompletionHandler?(error)
     }
 }

--- a/SwiftTemplate/Scenes/Home/CountriesViewModel.swift
+++ b/SwiftTemplate/Scenes/Home/CountriesViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import RealmSwift
 
 class CountriesViewModel: AppViewModel {
     private let countriesRepository: CountriesRepositoryProtocol!
@@ -22,21 +21,19 @@ class CountriesViewModel: AppViewModel {
     init(countriesRepository: CountriesRepository) {
         self.countriesRepository = countriesRepository
         super.init()
-        countriesRepository.refreshCompletionHandler = { [weak self] error in
-            self?.refreshCompletionHandler(error)
-        }
     }
 
     func refreshCountries() {
-        countriesRepository.refreshCountries()
+        countriesRepository.refreshCountries { [weak self] error in
+            self?.refreshCompletedCallback(error)
+        }
     }
 
-    private func refreshCompletionHandler(_ error: ApiError?) {
+    private func refreshCompletedCallback(_ error: ApiError?) {
         self.error.value = error
         if error == nil {
             countries = Array(countriesRepository.getCountries())
         }
         onRefreshCompleted?(error)
     }
-
 }

--- a/SwiftTemplate/Scenes/Login/LoginViewModel.swift
+++ b/SwiftTemplate/Scenes/Login/LoginViewModel.swift
@@ -21,19 +21,15 @@ class LoginViewModel: AppViewModel {
         self.loginRepository = loginRepository
         self.loginNavigator = loginNavigator
         super.init()
-        self.loginRepository.loginCompletionHandler = { [weak self] (error) in
-            self?.onLoginCompletedHandler(error)
-        }
     }
 
     func doLogin() {
-        loginRepository.signIn(username: username.value!, password: password.value!)
-    }
-
-    private func onLoginCompletedHandler(_ error: ApiError?) {
-        self.error.value = error
-        if error == nil {
-            loginNavigator.goToHome()
+        loginRepository.signIn(username: username.value!, password: password.value!) { [weak self] error in
+            if let error = error {
+                self?.error.value = error
+                return
+            }
+            self?.loginNavigator.goToHome()
         }
     }
 }

--- a/SwiftTemplate/Scenes/Registration/RegistrationViewModel.swift
+++ b/SwiftTemplate/Scenes/Registration/RegistrationViewModel.swift
@@ -8,33 +8,27 @@
 
 import Foundation
 import ReactiveKit
-import Bond
 
 class RegistrationViewModel: AppViewModel {
-    let userRepository: UserRepository!
-    let registrationNavigator: AppNavigatorProtocol!
+    private let userRepository: UserRepository!
+    private let registrationNavigator: AppNavigatorProtocol!
 
-    // Input
-    var username = Property<String?>("")
-    var password = Property<String?>("")
+    let username = Property<String?>("")
+    let password = Property<String?>("")
 
     init(userRepository: UserRepository, registrationNavigator: AppNavigatorProtocol) {
         self.userRepository = userRepository
         self.registrationNavigator = registrationNavigator
         super.init()
-        self.userRepository.userActionCompletionHandler = { [weak self] (error) in
-            self?.onUserActionCompletedHandler(error)
-        }
     }
 
     func doRegistration() {
-        userRepository.create(username: username.value!, password: password.value!)
-    }
-
-    func onUserActionCompletedHandler(_ error: ApiError?) {
-        self.error.value = error
-        if error == nil {
-            registrationNavigator.goToLogin()
+        userRepository.create(username: username.value!, password: password.value!) { [weak self] error in
+            if let error = error {
+                self?.error.value = error
+                return
+            }
+            self?.registrationNavigator.goToLogin()
         }
     }
 }


### PR DESCRIPTION
Reasons for abandoning usage of completion handlers are following:
  1. Readability - code written with completion handlers is very hard to
     read and follow because one must jump back and forth between
     completion handler definition and the actual repository call that will invoke
     that completion handler
     
  2. Leaking ViewModels - I find very often that when using completion handlers people create
     reference cycles that leak ViewModels and Repository objects. This
     can easily be avoided by instead of setting completion handler we set
     closure and capture current context weekly but this is something
     that is often forgotten.